### PR TITLE
Need Terminating Error to trigger Catch Statement

### DIFF
--- a/PowerShell Scanners/_Shared/Install and Import Module.ps1
+++ b/PowerShell Scanners/_Shared/Install and Import Module.ps1
@@ -9,7 +9,7 @@ param (
 # Install the module if it is not already installed, then load it.
 Try {
 
-    $null = Get-InstalledModule $ModuleName
+    $null = Get-InstalledModule $ModuleName -ErrorAction Stop
 
 } Catch {
 


### PR DESCRIPTION
Catch statement will not trigger without a terminating error.  Error generated by get-installedmodule on a missing module is not terminating.