### PR TITLE
Improve User Profile Size Scanner

### DIFF
--- a/PowerShell Scanners/User Profile Size/README.md
+++ b/PowerShell Scanners/User Profile Size/README.md
@@ -4,5 +4,25 @@ Recursively scans every folder in `C:\Users`, then adds up the size of every fil
 
 This scanner may take a while to run!
 
-# Author
+## Parameters
+
+```powershell
+-In
+```
+
+Accepts 'KB','MB', or 'GB' and returns friendly size representative of the chosen increment, rounded to 2 decimal places.
+
+Defaults to 'MB'.
+
+## Sample Output
+
+```powershell
+FolderName    FolderPath                   Size FriendlySize
+----------    ----------                   ---- ------------
+Administrator C:\Users\Administrator  496406547 473.41 MB
+All Users     C:\Users\All Users     7630976535 7277.47 MB
+```
+
+## Author
+
 Nate Blevins

--- a/PowerShell Scanners/User Profile Size/User Profile Size.ps1
+++ b/PowerShell Scanners/User Profile Size/User Profile Size.ps1
@@ -1,15 +1,29 @@
+[cmdletBinding()]
+param(
+    [ValidateSet('KB','MB','GB')]
+    [string]
+    $In = 'MB'
+)
+
 $ErrorActionPreference = "SilentlyContinue"
 
 $UserFolders = Get-ChildItem -Path "C:\Users" -Force -Directory
 
 ForEach ( $Folder in $UserFolders ) {
 
-    [UInt64]$FolderSize = ( Get-Childitem -Path $Folder.FullName -Force -Recurse | Measure-Object -Property "Length" -Sum ).Sum
+    $FolderSize = ( Get-Childitem -Path $Folder.FullName -Force -Recurse | Measure-Object -Property "Length" -Sum ).Sum
+    
+    switch($In){
+        'KB' {$FriendlySize = "$([math]::Round(($FolderSize /1KB),2)) KB"}
+        'MB' {$FriendlySize = "$([math]::Round(($FolderSize /1MB),2)) MB"}
+        'GB' {$FriendlySize = "$([math]::Round(($FolderSize /1GB),2)) GB"}
+    }
     
     [PSCustomObject]@{
         FolderName    = $Folder.BaseName
         FolderPath    = $Folder.FullName
         Size          = $FolderSize
+        FriendlySize  = $FriendlySize
     }
 
 }


### PR DESCRIPTION
Returning size in bytes is OK for reporting in other things, but a human-readable column is nice to have as well

Adds: 

- `-In` parameter which accepts 'KB','MB','GB' (Defaults to 'MB')

Updated:

- README.md with new parameter and sample output
- 'User Profile Size.ps1' with changes

Fixes #8 