### PR TITLE
Getwurebootstatus only returns bool rebootrequired property now

### DIFF
--- a/PowerShell Scanners/Get Available Windows Updates/Get Available Windows Updates.ps1
+++ b/PowerShell Scanners/Get Available Windows Updates/Get Available Windows Updates.ps1
@@ -3,71 +3,135 @@
 # The Collection object this cmdlet emits is really weird.
 # We have to assign it to a variable to get it to work properly in a pipeline.
 $GWU = Get-WindowsUpdate
-$GWU | ForEach-Object {
 
+If ($null -ne $GWU) {
+    $GWU | ForEach-Object {
+
+        [PSCustomObject]@{
+            "KB"                              = $_.KB
+            "Title"                           = $_.Title
+        
+            # Convert to bytes so it will display properly in Inventory
+            "Size"                            = [UInt64](Invoke-Expression $_.Size)
+
+            "Status"                          = $_.Status
+            "Description"                     = $_.Description
+            "RebootRequired"                  = $_.RebootRequired
+        
+            # Indicates whether the update is flagged to be automatically selected by Windows Update.
+            "AutoSelectOnWebSites"            = $_.AutoSelectOnWebSites
+
+            "CanRequireSource"                = $_.CanRequireSource
+            "Deadline"                        = $_.Deadline
+            "DeltaCompressedContentAvailable" = $_.DeltaCompressedContentAvailable
+            "DeltaCompressedContentPreferred" = $_.DeltaCompressedContentPreferred
+            "EulaAccepted"                    = $_.EulaAccepted
+            "IsBeta"                          = $_.IsBeta
+            "IsDownloaded"                    = $_.IsDownloaded
+            "IsHidden"                        = $_.IsHidden
+            "IsInstalled"                     = $_.IsInstalled
+            "IsMandatory"                     = $_.IsMandatory
+            "IsPresent"                       = $_.IsPresent
+            "IsUninstallable"                 = $_.IsUninstallable
+            "UninstallationNotes"             = $_.UninstallationNotes
+            "LastDeploymentChangeTime"        = $_.LastDeploymentChangeTime
+
+            # Convert Decimal to 64-bit Integer
+            "MaxDownloadSize"                 = [UInt64]$_.MaxDownloadSize
+            "MinDownloadSize"                 = [UInt64]$_.MinDownloadSize
+
+            "MsrcSeverity"                    = $_.MsrcSeverity
+        
+            # MHz
+            "RecommendedCpuSpeed"             = $_.RecommendedCpuSpeed
+
+            # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdate-get_recommendedharddiskspace
+            "RecommendedHardDiskSpace"        = [UInt64]($_.RecommendedHardDiskSpace * 1MB)
+
+            # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdate-get_recommendedmemory
+            "RecommendedMemorySize"           = [UInt64]($_.RecommendedMemory * 1MB)
+
+            "ReleaseNotes"                    = $_.ReleaseNotes
+            "SupportUrl"                      = $_.SupportUrl
+
+            # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-updatetype
+            "Type"                            = switch ($_.Type) {
+                1 { "Software" }
+                2 { "Driver" }
+                Default { "Unknown" } 
+            }
+
+            "DeploymentAction"                = $_.DeploymentAction
+            "DownloadPriority"                = $_.DownloadPriority
+        
+            # Indicates whether an update can be discovered only by browsing through the available updates.
+            "BrowseOnly"                      = $_.BrowseOnly
+
+            "PerUser"                         = $_.PerUser
+            "AutoSelection"                   = $_.AutoSelection
+            "AutoDownload"                    = $_.AutoDownload
+        }
+    }
+}
+else {
     [PSCustomObject]@{
-        "KB"                              = $_.KB
-        "Title"                           = $_.Title
+        "KB"                              = $null
+        "Title"                           = $null
         
         # Convert to bytes so it will display properly in Inventory
-        "Size"                            = [UInt64](Invoke-Expression $_.Size)
+        "Size"                            = $null
 
-        "Status"                          = $_.Status
-        "Description"                     = $_.Description
-        "RebootRequired"                  = $_.RebootRequired
+        "Status"                          = $null
+        "Description"                     = $null
+        "RebootRequired"                  = $null
         
         # Indicates whether the update is flagged to be automatically selected by Windows Update.
-        "AutoSelectOnWebSites"            = $_.AutoSelectOnWebSites
+        "AutoSelectOnWebSites"            = $null
 
-        "CanRequireSource"                = $_.CanRequireSource
-        "Deadline"                        = $_.Deadline
-        "DeltaCompressedContentAvailable" = $_.DeltaCompressedContentAvailable
-        "DeltaCompressedContentPreferred" = $_.DeltaCompressedContentPreferred
-        "EulaAccepted"                    = $_.EulaAccepted
-        "IsBeta"                          = $_.IsBeta
-        "IsDownloaded"                    = $_.IsDownloaded
-        "IsHidden"                        = $_.IsHidden
-        "IsInstalled"                     = $_.IsInstalled
-        "IsMandatory"                     = $_.IsMandatory
-        "IsPresent"                       = $_.IsPresent
-        "IsUninstallable"                 = $_.IsUninstallable
-        "UninstallationNotes"             = $_.UninstallationNotes
-        "LastDeploymentChangeTime"        = $_.LastDeploymentChangeTime
+        "CanRequireSource"                = $null
+        "Deadline"                        = $null
+        "DeltaCompressedContentAvailable" = $null
+        "DeltaCompressedContentPreferred" = $null
+        "EulaAccepted"                    = $null
+        "IsBeta"                          = $null
+        "IsDownloaded"                    = $null
+        "IsHidden"                        = $null
+        "IsInstalled"                     = $null
+        "IsMandatory"                     = $null
+        "IsPresent"                       = $null
+        "IsUninstallable"                 = $null
+        "UninstallationNotes"             = $null
+        "LastDeploymentChangeTime"        = $null
 
         # Convert Decimal to 64-bit Integer
-        "MaxDownloadSize"                 = [UInt64]$_.MaxDownloadSize
-        "MinDownloadSize"                 = [UInt64]$_.MinDownloadSize
+        "MaxDownloadSize"                 = $null
+        "MinDownloadSize"                 = $null
 
-        "MsrcSeverity"                    = $_.MsrcSeverity
+        "MsrcSeverity"                    = $null
         
         # MHz
-        "RecommendedCpuSpeed"             = $_.RecommendedCpuSpeed
+        "RecommendedCpuSpeed"             = $null
 
         # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdate-get_recommendedharddiskspace
-        "RecommendedHardDiskSpace"        = [UInt64]($_.RecommendedHardDiskSpace * 1MB)
+        "RecommendedHardDiskSpace"        = $null
 
         # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdate-get_recommendedmemory
-        "RecommendedMemorySize"           = [UInt64]($_.RecommendedMemory * 1MB)
+        "RecommendedMemorySize"           = $null
 
-        "ReleaseNotes"                    = $_.ReleaseNotes
-        "SupportUrl"                      = $_.SupportUrl
+        "ReleaseNotes"                    = $null
+        "SupportUrl"                      = $null
 
         # https://docs.microsoft.com/en-us/windows/win32/api/wuapi/ne-wuapi-updatetype
-        "Type"                            = switch ($_.Type) {
-            1 { "Software" }
-            2 { "Driver" }
-            Default { "Unknown" } 
-        }
+        "Type"                            = $null
 
-        "DeploymentAction"                = $_.DeploymentAction
-        "DownloadPriority"                = $_.DownloadPriority
+        "DeploymentAction"                = $null
+        "DownloadPriority"                = $null
         
         # Indicates whether an update can be discovered only by browsing through the available updates.
-        "BrowseOnly"                      = $_.BrowseOnly
+        "BrowseOnly"                      = $null
 
-        "PerUser"                         = $_.PerUser
-        "AutoSelection"                   = $_.AutoSelection
-        "AutoDownload"                    = $_.AutoDownload
+        "PerUser"                         = $null
+        "AutoSelection"                   = $null
+        "AutoDownload"                    = $null
     }
-
 }

--- a/PowerShell Scanners/Windows Update Last Installed/Windows Update Last Installed.ps1
+++ b/PowerShell Scanners/Windows Update Last Installed/Windows Update Last Installed.ps1
@@ -7,5 +7,5 @@ $lastResults = Get-WULastResults
 [PSCustomObject]@{
     LastInstallationDate = [DateTime] $lastResults.LastInstallationSuccessDate
     LastScanSuccessDate  = [DateTime] $lastResults.LastSearchSuccessDate
-    IsPendingReboot      = [Bool] (Get-WURebootStatus).RebootRequired
+    IsPendingReboot      = [Bool] (Get-WURebootStatus -Silent)
 }

--- a/PowerShell Scanners/Windows Update Last Installed/Windows Update Last Installed.ps1
+++ b/PowerShell Scanners/Windows Update Last Installed/Windows Update Last Installed.ps1
@@ -7,5 +7,5 @@ $lastResults = Get-WULastResults
 [PSCustomObject]@{
     LastInstallationDate = [DateTime] $lastResults.LastInstallationSuccessDate
     LastScanSuccessDate  = [DateTime] $lastResults.LastSearchSuccessDate
-    IsPendingReboot      = [Bool] (Get-WURebootStatus)
+    IsPendingReboot      = [Bool] (Get-WURebootStatus).RebootRequired
 }


### PR DESCRIPTION
The IsPendingReboot property was always returning as true because (Get-WURebootStatus) returned multiple properties instead of returning a true/false value.  I updated the script to only return the "RebootRequired" property