### PR TITLE
Get Windows Update History: Fix hang on newer Windows 10 builds

### DIFF
--- a/PowerShell Scanners/Get Windows Update History/Get Windows Update History.ps1
+++ b/PowerShell Scanners/Get Windows Update History/Get Windows Update History.ps1
@@ -1,3 +1,8 @@
 & '.\Install and Import Module.ps1' -ModuleName "PSWindowsUpdate"
 
-Get-WUHistory
+# Retrieve the Row Limit from a log file.
+$RowLimit = [Int32](Get-Content .\Scanner.log | Select-String 'First = (\d+)').Matches.Groups[1].Value
+
+# -Last limits the number of results. This is necessary in Windows 10 2004 and later.
+# https://github.com/pdq/PowerShell-Scanners/issues/74
+Get-WUHistory -Last $RowLimit


### PR DESCRIPTION
According to the forum post I mentioned in #74, adding `-Last` keeps Get-WUHistory from hanging on 2004 and later.

I used the Row Limit as the value for `-Last` so users only have to set the limit in 1 place.