### PR TITLE
Update Cipher Suite Detection Script

### DIFF
--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -1,21 +1,4 @@
-#Query Registry for transport protocols
-
-#SSLv2
-$SSLv2Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Server'
-$SSLv2Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Client' 
-
-#SSLv3
-$SSLv3Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server' 
-$SSLv3Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client' 
-
-#TLSv1.0
-$TLSv1Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server' 
-$TLSv1Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client' 
-
-#TLSv1.1
-$TLSv1_1Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server' 
-$TLSv1_1Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client' 
-
+# Create hashtable of protocols to check
 $Protocols = @{
     'SSL2.0 Server' = @{
         'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Server'
@@ -42,21 +25,34 @@ $Protocols = @{
         'Default' = $true
     }
 }
+
+# Create output object
 $output = [PSCustomObject]@{
     Host = $env:COMPUTERNAME
 }
+
+# Loop over protocol keys
 foreach ($Protocol in $Protocols.Keys) {
+    # Set status of the protocol to the configured default. Windows by default has them enabled (for now)
     $Status = $Protocols.$Protocol.Default
+
     if (Test-Path -Path $Protocols.$protocol.Path) {
+
+        # Get the property value of the registry path's Enabled key
         $EnablePropertyValue = (Get-ItemProperty -Path $Protocols.$protocol.Path | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue)
+
         if ($EnablePropertyValue -eq "0") {
             $Status = $false
         }
+
         if ($EnablePropertyValue -eq "1") {
             $Status = $true
         } 
     }
+
+    # Add this protocol name and the word Enabled along with the Status found to the output object
     Add-Member -InputObject $output -MemberType NoteProperty -Name ($Protocol + " Enabled") -value $Status
 }
 
+# Output the output object
 $output

--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -24,6 +24,18 @@ $Protocols = @{
         'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
         'Default' = $true
     }
+    'RC4 128/128'   = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 128/128'
+        'Default' = $true
+    }
+    'RC4 40/128'    = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 40/128'
+        'Default' = $true
+    }
+    'RC4 56/128'    = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\RC4 56/128'
+        'Default' = $true
+    }
 }
 
 # Create output object

--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -21,143 +21,159 @@ $TLSv1_1Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHAN
 
 if (Test-Path -Path $SSLv2Server) {
 
-    if ((Get-ItemPropertyValue -Path $SSLv2Server -Name Enabled -ErrorAction SilentlyContinue) -eq "0") {
+    if ((Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $SSLv2ServerEnabled = $false
     }
 
-    if ((Get-ItemPropertyValue -Path $SSLv2Server -Name Enabled -ErrorAction SilentlyContinue) -eq "1") {
+    if ((Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $SSLv2ServerEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $SSLv2Server)){
+}
+elseif (-Not (Test-Path -Path $SSLv2Server)) {
     $SSLv2ServerEnabled = "Key not found in registry."
-} else {
+}
+else {
     $SSLv2ServerEnabled = "Unknown issue occured. Requires manual review."
 }
 
 
-if(Test-Path -Path $SSLv2Client){
+if (Test-Path -Path $SSLv2Client) {
 
-    if((Get-ItemPropertyValue -Path $SSLv2Client -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $SSLv2Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $SSLv2ClientEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $SSLv2Client -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $SSLv2Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $SSLv2ClientEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $SSLv2Client)){
+}
+elseif (-Not (Test-Path -Path $SSLv2Client)) {
     $SSLv2ClientEnabled = "Key not found in registry"
-} else{
-      $SSLv2ClientEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $SSLv2ClientEnabled = "Unknown issue occured. Requires manual review."
 }
 
-if(Test-Path -Path $SSLv3Server){
+if (Test-Path -Path $SSLv3Server) {
 
-    if((Get-ItemPropertyValue -Path $SSLv3Server -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $SSLv3Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $SSLv3ServerEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $SSLv3Server -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $SSLv3Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $SSLv3ServerEnabled = $true
     }
 
-} elseif(-Not (Test-Path $SSLv3Server)){
+}
+elseif (-Not (Test-Path $SSLv3Server)) {
     $SSLv3ServerEnabled = "Key not found in registry"
-} else{
-      $SSLv3ServerEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $SSLv3ServerEnabled = "Unknown issue occured. Requires manual review."
 }
 
-if(Test-Path -Path $SSLv3Client){
+if (Test-Path -Path $SSLv3Client) {
 
-    if( (Get-ItemPropertyValue -Path $SSLv3Client -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $SSLv3Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $SSLv3ClientEnabled = $false
     }
 
-    if( (Get-ItemPropertyValue -Path $SSLv3Client -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $SSLv3Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $SSLv3ClientEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $SSLv3Client)){
+}
+elseif (-Not (Test-Path -Path $SSLv3Client)) {
     $SSLv3ClientEnabled = "Key not found in registry"
-} else{
-        $SSLv3ClientEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $SSLv3ClientEnabled = "Unknown issue occured. Requires manual review."
 }
 
-if(Test-Path -Path $TLSv1Server){
+if (Test-Path -Path $TLSv1Server) {
 
-    if((Get-ItemPropertyValue -Path $TLSv1Server -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $TLSv1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $TLSv1ServerEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $TLSv1Server -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $TLSv1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $TLSv1ServerEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $TLSv1Server)){
+}
+elseif (-Not (Test-Path -Path $TLSv1Server)) {
     $TLSv1ServerEnabled = "Key not found in registry"
-} else{
-      $TLSv1ServerEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $TLSv1ServerEnabled = "Unknown issue occured. Requires manual review."
 }
  
-if(Test-Path -Path $TLSv1Client){
+if (Test-Path -Path $TLSv1Client) {
 
-    if((Get-ItemPropertyValue -Path $TLSv1Client -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $TLSv1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $TLSv1ClientEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $TLSv1Client -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $TLSv1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $TLSv1ClientEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $TLSv1Client)){
+}
+elseif (-Not (Test-Path -Path $TLSv1Client)) {
     $TLSv1ClientEnabled = "Key not found in registry"
-} else{
-        $TLSv1ClientEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $TLSv1ClientEnabled = "Unknown issue occured. Requires manual review."
 }
 
-if(Test-Path -Path $TLSv1_1Server){
+if (Test-Path -Path $TLSv1_1Server) {
 
-    if((Get-ItemPropertyValue -Path $TLSv1_1ServerEnabled -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $TLSv1_1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $TLSv1_1ServerEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $TLSv1_1ServerEnabled -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $TLSv1_1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $TLSv1_1ServerEnabled = $true
     }
 
-} elseif(-Not (Test-Path -Path $TLSv1_1Server)){
+}
+elseif (-Not (Test-Path -Path $TLSv1_1Server)) {
     $TLSv1_1ServerEnabled = "Key not found in registry"
-} else{
-      $TLSv1_1ServerEnabled = "Unknown issue occured. Requires manual review."
+}
+else {
+    $TLSv1_1ServerEnabled = "Unknown issue occured. Requires manual review."
 }
  
-if(Test-Path -Path $TLSv1_1Client){
+if (Test-Path -Path $TLSv1_1Client) {
 
-    if((Get-ItemPropertyValue -Path $TLSv1_1Client -Name Enabled -ErrorAction SilentlyContinue) -eq "0"){
+    if ((Get-ItemProperty -Path $TLSv1_1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
         $TLSv1_1ClientEnabled = $false
     }
 
-    if((Get-ItemPropertyValue -Path $TLSv1_1Client -Name Enabled -ErrorAction SilentlyContinue) -eq "1"){
+    if ((Get-ItemProperty -Path $TLSv1_1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
         $TLSv1_1ClientEnabled = $true
     }
 
 
-} elseif(-Not (Test-Path -Path $TLSv1_1Client)){
-    $TLSv1_1ClientEnabled ="Key not found in registry"
-} else{
-        $TLSv1_1ClientEnabled = "Unknown issue occured. Requires manual review."
+}
+elseif (-Not (Test-Path -Path $TLSv1_1Client)) {
+    $TLSv1_1ClientEnabled = "Key not found in registry"
+}
+else {
+    $TLSv1_1ClientEnabled = "Unknown issue occured. Requires manual review."
 }
 
 
 #Report back to inventory
 [PSCustomObject]@{
     
-    Host = $env:COMPUTERNAME
-    'SSLv2 Server Enabled' = $SSLv2ServerEnabled
-    'SSLv2 Client Enabled' = $SSLv2ClientEnabled
-    'SSLv3 Server Enabled' = $SSLv3ServerEnabled
-    'SSLv3 Client Enabled' = $SSLv3ClientEnabled
+    Host                    = $env:COMPUTERNAME
+    'SSLv2 Server Enabled'  = $SSLv2ServerEnabled
+    'SSLv2 Client Enabled'  = $SSLv2ClientEnabled
+    'SSLv3 Server Enabled'  = $SSLv3ServerEnabled
+    'SSLv3 Client Enabled'  = $SSLv3ClientEnabled
     'TLS1.0 Server Enabled' = $TLSv1ServerEnabled
     'TLS1.0 Client Enabled' = $TLSv1ClientEnabled  
     'TLS1_1 Server Enabled' = $TLSv1_1ServerEnabled

--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -48,7 +48,7 @@ $output = [PSCustomObject]@{
 foreach ($Protocol in $Protocols.Keys) {
     $Status = $Protocols.$Protocol.Default
     if (Test-Path -Path $Protocols.$protocol.Path) {
-        $EnablePropertyValue = (Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue)
+        $EnablePropertyValue = (Get-ItemProperty -Path $Protocols.$protocol.Path | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue)
         if ($EnablePropertyValue -eq "0") {
             $Status = $false
         }

--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -1,4 +1,4 @@
-#Query Registry for cipher suites
+#Query Registry for transport protocols
 
 #SSLv2
 $SSLv2Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Server'
@@ -16,168 +16,47 @@ $TLSv1Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNE
 $TLSv1_1Server = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server' 
 $TLSv1_1Client = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client' 
 
-
-#Check if enabled
-
-if (Test-Path -Path $SSLv2Server) {
-
-    if ((Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $SSLv2ServerEnabled = $false
+$Protocols = @{
+    'SSL2.0 Server' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Server'
+        'Default' = $true
     }
-
-    if ((Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $SSLv2ServerEnabled = $true
+    'SSL2.0 Client' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 2.0\Client'
+        'Default' = $true
     }
-
-}
-elseif (-Not (Test-Path -Path $SSLv2Server)) {
-    $SSLv2ServerEnabled = "Key not found in registry."
-}
-else {
-    $SSLv2ServerEnabled = "Unknown issue occured. Requires manual review."
-}
-
-
-if (Test-Path -Path $SSLv2Client) {
-
-    if ((Get-ItemProperty -Path $SSLv2Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $SSLv2ClientEnabled = $false
+    'SSL3.0 Server' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server'
+        'Default' = $true
     }
-
-    if ((Get-ItemProperty -Path $SSLv2Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $SSLv2ClientEnabled = $true
+    'SSL3.0 Client' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client'
+        'Default' = $true
     }
-
-}
-elseif (-Not (Test-Path -Path $SSLv2Client)) {
-    $SSLv2ClientEnabled = "Key not found in registry"
-}
-else {
-    $SSLv2ClientEnabled = "Unknown issue occured. Requires manual review."
-}
-
-if (Test-Path -Path $SSLv3Server) {
-
-    if ((Get-ItemProperty -Path $SSLv3Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $SSLv3ServerEnabled = $false
+    'TLS1.1 Server' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server'
+        'Default' = $true
     }
-
-    if ((Get-ItemProperty -Path $SSLv3Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $SSLv3ServerEnabled = $true
+    'TLS1.1 Client' = @{
+        'Path'    = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client'
+        'Default' = $true
     }
-
 }
-elseif (-Not (Test-Path $SSLv3Server)) {
-    $SSLv3ServerEnabled = "Key not found in registry"
+$output = [PSCustomObject]@{
+    Host = $env:COMPUTERNAME
 }
-else {
-    $SSLv3ServerEnabled = "Unknown issue occured. Requires manual review."
-}
-
-if (Test-Path -Path $SSLv3Client) {
-
-    if ((Get-ItemProperty -Path $SSLv3Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $SSLv3ClientEnabled = $false
+foreach ($Protocol in $Protocols.Keys) {
+    $Status = $Protocols.$Protocol.Default
+    if (Test-Path -Path $Protocols.$protocol.Path) {
+        $EnablePropertyValue = (Get-ItemProperty -Path $SSLv2Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue)
+        if ($EnablePropertyValue -eq "0") {
+            $Status = $false
+        }
+        if ($EnablePropertyValue -eq "1") {
+            $Status = $true
+        } 
     }
-
-    if ((Get-ItemProperty -Path $SSLv3Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $SSLv3ClientEnabled = $true
-    }
-
-}
-elseif (-Not (Test-Path -Path $SSLv3Client)) {
-    $SSLv3ClientEnabled = "Key not found in registry"
-}
-else {
-    $SSLv3ClientEnabled = "Unknown issue occured. Requires manual review."
+    Add-Member -InputObject $output -MemberType NoteProperty -Name ($Protocol + " Enabled") -value $Status
 }
 
-if (Test-Path -Path $TLSv1Server) {
-
-    if ((Get-ItemProperty -Path $TLSv1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $TLSv1ServerEnabled = $false
-    }
-
-    if ((Get-ItemProperty -Path $TLSv1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $TLSv1ServerEnabled = $true
-    }
-
-}
-elseif (-Not (Test-Path -Path $TLSv1Server)) {
-    $TLSv1ServerEnabled = "Key not found in registry"
-}
-else {
-    $TLSv1ServerEnabled = "Unknown issue occured. Requires manual review."
-}
- 
-if (Test-Path -Path $TLSv1Client) {
-
-    if ((Get-ItemProperty -Path $TLSv1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $TLSv1ClientEnabled = $false
-    }
-
-    if ((Get-ItemProperty -Path $TLSv1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $TLSv1ClientEnabled = $true
-    }
-
-}
-elseif (-Not (Test-Path -Path $TLSv1Client)) {
-    $TLSv1ClientEnabled = "Key not found in registry"
-}
-else {
-    $TLSv1ClientEnabled = "Unknown issue occured. Requires manual review."
-}
-
-if (Test-Path -Path $TLSv1_1Server) {
-
-    if ((Get-ItemProperty -Path $TLSv1_1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $TLSv1_1ServerEnabled = $false
-    }
-
-    if ((Get-ItemProperty -Path $TLSv1_1Server | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $TLSv1_1ServerEnabled = $true
-    }
-
-}
-elseif (-Not (Test-Path -Path $TLSv1_1Server)) {
-    $TLSv1_1ServerEnabled = "Key not found in registry"
-}
-else {
-    $TLSv1_1ServerEnabled = "Unknown issue occured. Requires manual review."
-}
- 
-if (Test-Path -Path $TLSv1_1Client) {
-
-    if ((Get-ItemProperty -Path $TLSv1_1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "0") {
-        $TLSv1_1ClientEnabled = $false
-    }
-
-    if ((Get-ItemProperty -Path $TLSv1_1Client | Select-Object -ExpandProperty Enabled -ErrorAction SilentlyContinue) -eq "1") {
-        $TLSv1_1ClientEnabled = $true
-    }
-
-
-}
-elseif (-Not (Test-Path -Path $TLSv1_1Client)) {
-    $TLSv1_1ClientEnabled = "Key not found in registry"
-}
-else {
-    $TLSv1_1ClientEnabled = "Unknown issue occured. Requires manual review."
-}
-
-
-#Report back to inventory
-[PSCustomObject]@{
-    
-    Host                    = $env:COMPUTERNAME
-    'SSLv2 Server Enabled'  = $SSLv2ServerEnabled
-    'SSLv2 Client Enabled'  = $SSLv2ClientEnabled
-    'SSLv3 Server Enabled'  = $SSLv3ServerEnabled
-    'SSLv3 Client Enabled'  = $SSLv3ClientEnabled
-    'TLS1.0 Server Enabled' = $TLSv1ServerEnabled
-    'TLS1.0 Client Enabled' = $TLSv1ClientEnabled  
-    'TLS1_1 Server Enabled' = $TLSv1_1ServerEnabled
-    'TLS1_1 Client Enabled' = $TLSv1_1ClientEnabled
-    
-} 
-
+$output

--- a/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
+++ b/PowerShell Scanners/Cipher Suite Detection/Cipher Suite Detection.ps1
@@ -59,7 +59,7 @@ foreach ($Protocol in $Protocols.Keys) {
 
         if ($EnablePropertyValue -eq "1") {
             $Status = $true
-        } 
+        }
     }
 
     # Add this protocol name and the word Enabled along with the Status found to the output object


### PR DESCRIPTION
I've rewritten the Cipher Suite Detection Script. It will now fix the following issues:

- #89 
- #92 

It is also written so that it is easy to add, remove, or adjust the protocols using the hash table at the beginning as opposed to copy/pasting the same code over and over. 

Now the return data will always be either true or false for each protocol or cipher.

I also added RC4 Detection per [instructions on Microsoft's website.](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/manage-ssl-protocols-in-ad-fs)