### PR TITLE
skip not readable categories

### DIFF
--- a/PowerShell Scanners/Dell BIOS Information/Dell BIOS Information.ps1
+++ b/PowerShell Scanners/Dell BIOS Information/Dell BIOS Information.ps1
@@ -6,7 +6,7 @@ if (Get-CimInstance -ClassName Win32_ComputerSystem -Filter "Manufacturer LIKE '
     & '.\Install and Import Module.ps1' -ModuleName $ModuleName
     Get-ChildItem DellSmbios:\ | ForEach-Object {
         $Category = $_.Category
-        Get-ChildItem DellSmbios:\"$Category" | ForEach-Object {
+        Get-ChildItem DellSmbios:\"$Category" -ErrorAction SilentlyContinue | ForEach-Object {
             [PSCustomObject]@{
                 Category     = $Category
                 Attribute    = $_.Attribute


### PR DESCRIPTION
if i run it without changes i get an error.

```
Get-ChildItem : UEFI variable FORCED_NETWORK_FLAG may not be supported on this platform or not defined yet, try to
define by set command. try "set-item .\ForcedNetworkFlag 0"
```