### PR TITLE
Change Mapped Printer scan profile to scan as the logged on user

### DIFF
--- a/PowerShell Scanners/Mapped Printers/Scan Profile.xml
+++ b/PowerShell Scanners/Mapped Printers/Scan Profile.xml
@@ -18,6 +18,7 @@
     <Description>Retrieves the mapped printers of logged-on users.</Description>
     <ScanProfileId value="25" />
     <Name>PS - Mapped Printers</Name>
+    <ScanAs>LoggedOnUser</ScanAs>
     <ScheduleTriggerSet name="ScheduleTriggers">
       <Triggers type="list" />
     </ScheduleTriggerSet>


### PR DESCRIPTION
The Mapped Printers scanner only works when scanning as the logged on user. When importing the scanner, it will be set to scan as the scan user, which will return no results.
This PR adds a line to the scan profile XML to set the scan user to the logged on user.
Tested and working on PDQ Inventory 19.3.526.0.