### PR TITLE
Allow description to be set from New-Scanner.ps1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You can use `New-Scanner.ps1` in the `PowerShell Scanners` folder to create thes
 
 ```PowerShell
 Set-Location 'C:\PowerShell-Scanners\PowerShell Scanners'
-.\New-Scanner.ps1 -Name 'Your desired name'
+.\New-Scanner.ps1 -Name 'Your desired name' -Description "Your desired brief description"
 ```
 
 ## Bug Reports

--- a/PowerShell Scanners/New-Scanner.ps1
+++ b/PowerShell Scanners/New-Scanner.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param (
     [Parameter(Mandatory = 'True')]
-    [String]$Name
+    [String]$Name,
+    [String]$Description
 )
 
 $null = Copy-Item -Path '.\_Template' -Destination ".\$Name" -Recurse
@@ -18,6 +19,12 @@ $ScanProfile.'AdminArsenal.Export'.ScanProfile.Scanners.Scanner.Name = $Name
 $ScanProfile.'AdminArsenal.Export'.ScanProfile.Scanners.Scanner.UID = (New-Guid) -replace '-'
 $ScanProfile.'AdminArsenal.Export'.ScanProfile.Scanners.Scanner.FileName = "C:\PowerShell-Scanners\PowerShell Scanners\$Name\$Name.ps1"
 
+if($Description) {
+    $ScanProfile.'AdminArsenal.Export'.ScanProfile.Description = $Description
+}
+
 $ScanProfile.Save("$PWD\Scan Profile.xml")
 
-Write-Warning "Don't forget to update the Description in 'Scan Profile.xml'!"
+if (!$Description) {
+    Write-Warning "Don't forget to update the Description in 'Scan Profile.xml'!"
+}


### PR DESCRIPTION
It is not inventive to manually fill in the description in `Scan Profile.xml`. This commit allows the description to be passed along to `New Scanner.ps1`

The new description parameter is not mandatory. 