### PR TITLE
Battery Status: Set the NumberDecimalSeperator to "."

### DIFF
--- a/PowerShell Scanners/Battery Status/Battery Status.ps1
+++ b/PowerShell Scanners/Battery Status/Battery Status.ps1
@@ -1,4 +1,8 @@
-﻿$Batteries = (Get-WmiObject -Class "BatteryStatus" -Namespace "ROOT\WMI" -ErrorAction SilentlyContinue)
+﻿$culture = [System.Globalization.CultureInfo]::CurrentCulture.Clone()
+$culture.NumberFormat.NumberDecimalSeparator = "."
+[System.Threading.Thread]::CurrentThread.CurrentCulture = $culture
+
+$Batteries = (Get-WmiObject -Class "BatteryStatus" -Namespace "ROOT\WMI" -ErrorAction SilentlyContinue)
 $AllBatteryData = Get-WmiObject -Class "BatteryStaticData" -Namespace "ROOT\WMI"
 $AllCharges = (Get-WmiObject -Class "BatteryFullChargedCapacity" -Namespace "ROOT\WMI").FullChargedCapacity
 $BatteryIndex = 0


### PR DESCRIPTION
When the script runs on a system where the local number format has something else then "." as decimal seperator (in our case ",") PDQ Inventory ignores the decimal seperator and stores it as integer. (99,98 becomes 9998).

This change sets the decimal seperator to "." for the script.