### PR TITLE
Add Autopilot Hardware Hash scanner

### DIFF
--- a/PowerShell Scanners/AutoPilot Hash/AutoPilot_Hash.xml
+++ b/PowerShell Scanners/AutoPilot Hash/AutoPilot_Hash.xml
@@ -1,15 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<AdminArsenal.Export>
+<AdminArsenal.Export Code="PDQInventory" Name="PDQ Inventory" Version="19.3.30.0" MinimumVersion="19.0">
   <ScanProfile>
-    <Name>Hardware Hash</Name>
-    <Description>Harvests Windows Autopilot Hardware Hashes for Intune enrollment.</Description>
-    <Scanners>
+    <Collections type="list" />
+    <Scanners type="list">
       <Scanner>
-        <Name>HardwareHash</Name>
-        <Type>PowerShell</Type>
-        <ScriptSource>File</ScriptSource>
-        <ScriptFile>Get-AutoPilotHash.ps1</ScriptFile>
+        <ModifiedDate></ModifiedDate>
+        <Name>Hardware Hash</Name>
+        <UID></UID>
+        <Script></Script>
+        <FileName>C:\PowerShell-Scanners\PowerShell Scanners\AutoPilot Hash\Get-AutoPilotHash.ps1</FileName>
+        <Parameters></Parameters>
+        <AdditionalFiles></AdditionalFiles>
+        <RowLimit value="100" />
+        <TypeName>PowerShell</TypeName>
+        <SourceScannerId value="90" />
       </Scanner>
     </Scanners>
+    <Description>Harvests Windows Autopilot Hardware Hashes for Intune enrollment.</Description>
+    <ScanProfileId value="33" />
+    <Name></Name>
+    <ScheduleTriggerSet name="ScheduleTriggers">
+      <Triggers type="list" />
+    </ScheduleTriggerSet>
   </ScanProfile>
 </AdminArsenal.Export>

--- a/PowerShell Scanners/AutoPilot Hash/AutoPilot_Hash.xml
+++ b/PowerShell Scanners/AutoPilot Hash/AutoPilot_Hash.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AdminArsenal.Export>
+  <ScanProfile>
+    <Name>Hardware Hash</Name>
+    <Description>Harvests Windows Autopilot Hardware Hashes for Intune enrollment.</Description>
+    <Scanners>
+      <Scanner>
+        <Name>HardwareHash</Name>
+        <Type>PowerShell</Type>
+        <ScriptSource>File</ScriptSource>
+        <ScriptFile>Get-AutoPilotHash.ps1</ScriptFile>
+      </Scanner>
+    </Scanners>
+  </ScanProfile>
+</AdminArsenal.Export>

--- a/PowerShell Scanners/AutoPilot Hash/Get-AutoPilotHash.ps1
+++ b/PowerShell Scanners/AutoPilot Hash/Get-AutoPilotHash.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Retrieves the Windows Autopilot Hardware Hash for Intune registration.
+
+.DESCRIPTION
+    Queries WMI for the MDM_DevDetail_Ext01 class to extract the 4K hardware hash.
+    Used for manual enrollment of existing devices into Windows Autopilot.
+
+.OUTPUTS
+    PSCustomObject
+#>
+
+$WmiPath = "root/cimv2/mdm/dmmap"
+$ClassName = "MDM_DevDetail_Ext01"
+
+try {
+    # Query the hash from WMI
+    $DevDetail = Get-CimInstance -Namespace $WmiPath -ClassName $ClassName -Filter "InstanceID='Ext' AND ParentID='./DevDetail'" -ErrorAction Stop
+    
+    [PSCustomObject]@{
+        ComputerName = $env:COMPUTERNAME
+        HardwareHash = $DevDetail.DeviceHardwareData
+        SerialNumber = (Get-CimInstance Win32_Bios).SerialNumber
+    }
+}
+catch {
+    # If it fails (e.g. older Windows versions), return an error message
+    [PSCustomObject]@{
+        ComputerName = $env:COMPUTERNAME
+        HardwareHash = "Error: WMI Path Not Found (Requires Win 10/11 1703+)"
+        SerialNumber = "N/A"
+    }
+}

--- a/PowerShell Scanners/AutoPilot Hash/README.md
+++ b/PowerShell Scanners/AutoPilot Hash/README.md
@@ -1,0 +1,80 @@
+Hardware Hash
+
+
+
+This scanner retrieves the Windows Autopilot Hardware Hash and Serial Number from Windows 10/11 devices. This is essential for IT administrators transitioning from Active Directory to Microsoft Entra ID (formerly Azure AD) and Intune.
+
+
+
+
+
+Description
+
+
+
+The scanner queries the MDM\_DevDetail\_Ext01 WMI class to extract the DeviceHardwareData (the 4K hardware hash). This data is required for manual device registration in the Windows Autopilot service.
+
+
+
+
+
+Columns Returned
+
+
+
+ComputerName: The local hostname.
+
+
+
+HardwareHash: The encoded 4K hardware hash.
+
+
+
+SerialNumber: The hardware serial number from the BIOS.
+
+
+
+
+
+Requirements
+
+
+
+OS: Windows 10 version 1703 or later.
+
+
+
+Hardware: TPM 2.0 is recommended for reliable hash generation.
+
+
+
+
+
+Usage
+
+
+
+1. Import the AutoPilot_Hash.xml scan profile into PDQ Inventory.
+
+
+
+2\. Ensure the Get-AutoPilotHash.ps1 file is located in a directory accessible by your PDQ console (or update the scan profile path).
+
+
+
+3\. Scan target computers.
+
+
+
+4\. Export the results to a CSV using a custom SQL report to match the Intune upload format: Device Serial Number,Windows Product ID,Hardware Hash.
+
+
+
+
+
+Contributor
+
+
+
+Gemini AI and Aaron Smith
+


### PR DESCRIPTION
This scanner returns the hardware hash for a windows device for later importing into Intune for AutoPilot.