### PR TITLE
Fixed enabled status for extensions

### DIFF
--- a/PowerShell Scanners/Chromium-based Browser Extensions/Chromium-based Browser Extensions.ps1
+++ b/PowerShell Scanners/Chromium-based Browser Extensions/Chromium-based Browser Extensions.ps1
@@ -217,10 +217,21 @@ Foreach ( $User in $UserPaths ) {
 
                 }
 
+                # If disable_reasons is empty, it means extension is enabled.
+                # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/browser/disable_reason.h
+				if ( $Extension.disable_reasons ) {
+
+                    $Status = $false
+                }
+                else {
+                    
+                    $Status = $true
+                }
+
                 $Output = [Ordered]@{
                     'Browser'           =           $BrowserName
                     'Name'              =           $Name
-                    'Enabled'           = [Bool]    $Extension.state
+                    'Enabled'           = [Bool]    $Status
                     'Description'       = [String]  $Extension.manifest.description
                     'Extension Version' = [String]  $Extension.manifest.version
                     'Browser Version'   = [String]  $PreferencesJson.extensions."$($Browser.LastVersion)"


### PR DESCRIPTION
The "status" key in Status Preferences file is no longer there, it seems like it's been replaced by disable_reasons. Use that to fix the "Enabled" value in $Output which is broken at the moment.