### PR TITLE
fix: add DriverName field to Mapped Printers scanner

### DIFF
--- a/PowerShell Scanners/Mapped Printers/Mapped Printers.ps1
+++ b/PowerShell Scanners/Mapped Printers/Mapped Printers.ps1
@@ -1,1 +1,1 @@
-Get-CimInstance Win32_Printer | Where-Object Name -Like "\\*" | Select-Object ShareName, Name, Default
+Get-CimInstance Win32_Printer | Where-Object Name -Like "\\*" | Select-Object ShareName, Name, DriverName, Default


### PR DESCRIPTION
## Summary

- Adds `DriverName` to the `Select-Object` output of the Mapped Printers scanner
- The value is already available from `Win32_Printer`; it just wasn't being selected

## Change

```diff
- Get-CimInstance Win32_Printer | Where-Object Name -Like "\*" | Select-Object ShareName, Name, Default
+ Get-CimInstance Win32_Printer | Where-Object Name -Like "\*" | Select-Object ShareName, Name, DriverName, Default
```

## Test plan
- [ ] Run scanner against a machine with mapped network printers and confirm `DriverName` appears in results

Closes #111