### PR TITLE
fix: add quser fallback for currently logged-on users

### DIFF
--- a/PowerShell Scanners/User Last Logged On/User Last Logged On.ps1
+++ b/PowerShell Scanners/User Last Logged On/User Last Logged On.ps1
@@ -5,9 +5,10 @@ param (
     [Switch]$Lowercase
 )
 
+$Results = New-Object System.Collections.ArrayList
 $UserArray = New-Object System.Collections.ArrayList
 
-# Query all logon events with id 4624 
+# Query all logon events with id 4624
 Get-EventLog -LogName "Security" -newest 200 -InstanceId 4624 -ErrorAction "SilentlyContinue" | ForEach-Object {
 
     $EventMessage = $_
@@ -22,13 +23,13 @@ Get-EventLog -LogName "Security" -newest 200 -InstanceId 4624 -ErrorAction "Sile
     }
 
     # Look for events that contain local or remote logon events, while ignoring Windows service accounts
-    if ( ( $LogonType -in "2", "10", "11" ) -and ( $AccountName -notmatch "^(DWM|UMFD)-\d" ) ) {
-    
+    if ( ( $LogonType -in "2", "10", "11" ) -and ( $AccountName -notmatch "^(DWM|UMFD)-\d" -and ($AccountName -ne "") ) ) {
+
         # Skip duplicate names
         if ( $UserArray -notcontains $AccountName ) {
 
             $null = $UserArray.Add($AccountName)
-            
+
             # Translate the Logon Type
             if ( $LogonType -eq "2" ) {
 
@@ -39,19 +40,68 @@ Get-EventLog -LogName "Security" -newest 200 -InstanceId 4624 -ErrorAction "Sile
                 $LogonTypeName = "Remote"
 
             } elseif ( $LogonType -eq "11" ) {
-                
+
                 $LogonTypeName = "Cached"
             }
 
             # Build an object containing the Username, Logon Type, and Last Logon time
-            [PSCustomObject]@{
+            $null = $Results.Add([PSCustomObject]@{
                 Username  = $AccountName
                 LogonType = $LogonTypeName
                 LastLogon = [DateTime]$EventMessage.TimeGenerated.ToString("yyyy-MM-dd HH:mm:ss")
-            }  
+            })
 
         }
 
     }
 
 }
+
+# Fall back to quser to catch currently logged-on users that have no matching security event
+# (common on machines where only logon types 3/5 are present, e.g. remote-only or VDI sessions)
+try {
+    $queryUser = quser 2>&1
+}
+catch {
+    $Results
+    return
+}
+
+if ( $LASTEXITCODE -ne 0 ) {
+
+    $Results
+    return
+
+}
+
+$userName = $null
+if ( $queryUser ) {
+
+    if ( $queryUser -match '\s(\S+)\s+\d+\s' ) {
+        $userName = $matches[1]
+    }
+
+}
+
+if ( $null -eq $userName ) {
+
+    $Results
+    return
+
+}
+
+if ( $Lowercase ) {
+    $userName = $userName.ToLower()
+}
+
+if ( $UserArray -notcontains $userName ) {
+
+    $null = $Results.Add([PSCustomObject]@{
+        Username  = $userName
+        LogonType = "Current User"
+        LastLogon = [DateTime](Get-Date)
+    })
+
+}
+
+$Results

--- a/PowerShell Scanners/User Last Logged On/User Last Logged On.ps1
+++ b/PowerShell Scanners/User Last Logged On/User Last Logged On.ps1
@@ -61,8 +61,7 @@ Get-EventLog -LogName "Security" -newest 200 -InstanceId 4624 -ErrorAction "Sile
 # (common on machines where only logon types 3/5 are present, e.g. remote-only or VDI sessions)
 try {
     $queryUser = quser 2>&1
-}
-catch {
+} catch {
     $Results
     return
 }


### PR DESCRIPTION
## Summary

- Fixes the scanner returning no data on ~80% of machines where security event log only contains logon types 3/5 (network/service), not 2/10/11
- Adds a `quser` fallback that runs after the event log scan and captures the currently logged-on user if they weren't already found
- Guards against empty account names (adds `$AccountName -ne ""` check)
- Wraps `quser` in a try/catch and checks `$LASTEXITCODE` to handle machines with no logged-on user cleanly
- Collects results into a `$Results` ArrayList so the event log scan and quser results are emitted together

## Root cause

On many machines (especially those accessed primarily via remote/network sessions), interactive logon events with types 2/10/11 are absent from the Security log. The scanner only looked at those types, so it returned nothing even though a user was actively logged on.

## Test plan
- [ ] Run scanner on a machine with only type-3/5 events in the Security log — confirm the currently logged-on user is returned with `LogonType = "Current User"`
- [ ] Run scanner on a machine with normal type-2 events — confirm existing behavior is unchanged
- [ ] Run scanner on a machine with no logged-on user — confirm no errors and empty output

Closes #110