### PR TITLE
fix: correct service flags so -WSUS actually respects WSUS

### DIFF
--- a/PowerShell Scanners/Get Available Windows Updates/Get Available Windows Updates.ps1
+++ b/PowerShell Scanners/Get Available Windows Updates/Get Available Windows Updates.ps1
@@ -7,10 +7,14 @@ Param(
 # The Collection object this cmdlet emits is really weird.
 # We have to assign it to a variable to get it to work properly in a pipeline.
 If ($WSUS) {
-    $GWU = Get-WindowsUpdate -WindowsUpdate
+    # No service flag: the Windows Update Agent uses the service configured by GPO (i.e. WSUS).
+    # -WindowsUpdate forces the online WU service ID and bypasses WSUS filtering.
+    $GWU = Get-WindowsUpdate
 }
 Else {
-    $GWU = Get-WindowsUpdate 
+    # -MicrosoftUpdate queries Microsoft's catalog directly, returning all available updates
+    # regardless of what the machine's WSUS policy would approve.
+    $GWU = Get-WindowsUpdate -MicrosoftUpdate
 }
 
 <#


### PR DESCRIPTION
## Summary

- Fixes the `-WSUS` parameter having no effect: the scanner was returning non-approved updates even when `-WSUS` was specified
- Swaps the service flags: `-WSUS` now calls `Get-WindowsUpdate` with no service flag (so the WU Agent routes through the WSUS server configured by Group Policy), and the default (no `-WSUS`) now uses `-MicrosoftUpdate` to query Microsoft's full catalog

## Root cause

The original code called `Get-WindowsUpdate -WindowsUpdate` when `-WSUS` was specified. In PSWindowsUpdate, `-WindowsUpdate` explicitly requests service ID `9482F4B4-E343-43B6-B170-9A65BC822C77` (the online Windows Update service), which bypasses WSUS filtering entirely and returns all Microsoft-hosted updates regardless of approval status.

The correct approach for WSUS is to call `Get-WindowsUpdate` with **no service flag**. The Windows Update Agent then uses whatever service is configured by Group Policy — which is the WSUS server when the machine is WSUS-managed.

## Change

```diff
  If ($WSUS) {
-     $GWU = Get-WindowsUpdate -WindowsUpdate
+     # No service flag: WU Agent uses the GPO-configured service (WSUS)
+     $GWU = Get-WindowsUpdate
  }
  Else {
-     $GWU = Get-WindowsUpdate
+     # -MicrosoftUpdate queries Microsoft's catalog directly, bypassing WSUS
+     $GWU = Get-WindowsUpdate -MicrosoftUpdate
  }
```

## Test plan
- [ ] Run scanner with `-WSUS` on a machine pointing to a WSUS server — confirm only WSUS-approved updates are returned
- [ ] Run scanner without `-WSUS` — confirm all available updates are returned (including those not in WSUS)
- [ ] Run on a non-WSUS machine — confirm default behavior is unchanged

Closes #109