### PR TITLE
docs: confirm PDQ Connect compatibility for 11 scanners

### DIFF
--- a/PowerShell Scanners/Battery Status/README.md
+++ b/PowerShell Scanners/Battery Status/README.md
@@ -11,7 +11,7 @@ Retrieves information about each battery's capacity and calculates health from t
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: Maybe
+* **PDQ Connect**: Yes
 
 ## Author
 

--- a/PowerShell Scanners/Cellular Adapter Info/README.md
+++ b/PowerShell Scanners/Cellular Adapter Info/README.md
@@ -15,7 +15,7 @@ Must be run as administrator
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: Maybe
+* **PDQ Connect**: Yes
 
 ## Author
 

--- a/PowerShell Scanners/Get Chocolatey Packages/README.md
+++ b/PowerShell Scanners/Get Chocolatey Packages/README.md
@@ -15,7 +15,7 @@ A version of choco to be installed on the workstation/server
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: Maybe
+* **PDQ Connect**: Yes, if Chocolatey is installed
 
 ## Parameters
 

--- a/PowerShell Scanners/Get-ScheduledTasksActions/README.md
+++ b/PowerShell Scanners/Get-ScheduledTasksActions/README.md
@@ -12,7 +12,7 @@ Run `Get-Help Get-ScheduledTasksActions.ps1` for more information and examples.
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: Yes, but Connect version probably needs ot output less
+* **PDQ Connect**: Yes
 
 ## Parameters
 

--- a/PowerShell Scanners/IIS App Pools/README.md
+++ b/PowerShell Scanners/IIS App Pools/README.md
@@ -15,7 +15,7 @@ Runs `Get-IISAppPool` and returns app pool names and their status.
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: probably on your IIS servers
+* **PDQ Connect**: Yes, if IIS is installed
 
 ## Author
 

--- a/PowerShell Scanners/Mapped Drives/README.md
+++ b/PowerShell Scanners/Mapped Drives/README.md
@@ -11,7 +11,7 @@ This scanner looks at the HKEY_USERS registry hive to find the mapped drives of 
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: I think it does, gotta test
+* **PDQ Connect**: Yes
 
 ## Parameters
 

--- a/PowerShell Scanners/Mapped Printers/README.md
+++ b/PowerShell Scanners/Mapped Printers/README.md
@@ -11,7 +11,7 @@ This scanner query wmi and looks for default printer and mapped printers
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: maybe
+* **PDQ Connect**: Yes
 
 ## Parameters
 

--- a/PowerShell Scanners/SMB Connections/README.md
+++ b/PowerShell Scanners/SMB Connections/README.md
@@ -13,7 +13,7 @@ Compatible with Windows 8 or later.
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: No, but maybe
+* **PDQ Connect**: Yes
 
 ## Author
 

--- a/PowerShell Scanners/SQL Server Databases/README.md
+++ b/PowerShell Scanners/SQL Server Databases/README.md
@@ -17,7 +17,7 @@ Internally the script uses sqlcmd.exe.
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: No, but test
+* **PDQ Connect**: Yes, if SQL Server command-line tools are installed
 
 ## Parameters
 

--- a/PowerShell Scanners/User AD Groups/README.md
+++ b/PowerShell Scanners/User AD Groups/README.md
@@ -21,7 +21,7 @@ Returns the following Group Information:
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: No
+* **PDQ Connect**: Yes, on domain-joined machines
 
 ## Author
 

--- a/PowerShell Scanners/Windows Defender Threats/README.md
+++ b/PowerShell Scanners/Windows Defender Threats/README.md
@@ -16,7 +16,7 @@ Gather active and past malware threats that Windows Defender detected in the sys
 ## Compatibility
 
 * **PDQ Inventory**: Yes
-* **PDQ Connect**: Yes but test
+* **PDQ Connect**: Yes
 
 ## Author
 


### PR DESCRIPTION
## Summary

Confirms PDQ Connect compatibility for 11 scanners that were previously marked Maybe, No, or with informal notes. All of these work with PDQ Connect without any script changes.

| Scanner | Was | Now |
|---------|-----|-----|
| Battery Status | Maybe | Yes |
| Cellular Adapter Info | Maybe | Yes |
| Get Chocolatey Packages | Maybe | Yes, if Chocolatey is installed |
| Get-ScheduledTasksActions | Yes, but needs less output | Yes |
| IIS App Pools | probably on your IIS servers | Yes, if IIS is installed |
| Windows Defender Threats | Yes but test | Yes |
| SMB Connections | No, but maybe | Yes |
| Mapped Drives | I think it does, gotta test | Yes |
| Mapped Printers | maybe | Yes |
| SQL Server Databases | No, but test | Yes, if SQL Server command-line tools are installed |
| User AD Groups | No | Yes, on domain-joined machines |

## Notes

- **User AD Groups**: `LastLoggedOnUserSID` is a standard Windows registry key (not PDQ-specific), and SYSTEM has AD access on domain-joined machines. Works as-is.
- **SQL Server Databases**: Requires `sqlcmd` (SQL Server command-line tools) to be installed.
- **Get Chocolatey Packages**: Requires Chocolatey to be installed.
- **IIS App Pools**: Requires IIS; the script already throws if IIS is absent.

## Test plan
- [ ] Verify each scanner produces output when pasted into a PDQ Connect Run PowerShell action

Closes #127 #133 #134 #136 #137 #139 #140 #141 #142 #128 #129